### PR TITLE
SCM - ingore npm and snyk cache for now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,12 @@
 .env.test.local
 .env.production.local
 yarn.lock
+package-lock.json
 
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+
+# Snyk security scanning
+.dccache


### PR DESCRIPTION
Just ignoring the snyk cache.
Also until we talk about deployment I ignored the package-lock file. 